### PR TITLE
Update S3 bucket name and binstar package name

### DIFF
--- a/devtools/ci/index.html
+++ b/devtools/ci/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!-- <html><head><meta http-equiv=Refresh content="0;url=/latest/"></head></html> -->
+<html><head><script>
+request = new XMLHttpRequest();
+request.open('GET', 'https://api.github.com/repos/choderalab/openpathsampling/releases', true);
+
+request.onreadystatechange = function() {
+  if (this.readyState === 4){
+    if (this.status >= 200 && this.status < 400){
+      // Success!
+      var data = JSON.parse(this.responseText);
+      // get the latest release
+      var version = data[0].tag_name;
+      window.location.replace("/" + version);
+    } else {
+        window.location.replace("/latest");
+    }
+  }
+};
+
+request.send();
+request = null;
+</script></head></html>

--- a/devtools/ci/push-docs-to-s3.py
+++ b/devtools/ci/push-docs-to-s3.py
@@ -31,3 +31,13 @@ secret_key = {AWS_SECRET_ACCESS_KEY}
             bucket=BUCKET_NAME
     )
     return_val = subprocess.call(cmd.split())
+
+    # Sync index file.
+    template = ('s3cmd --config {config} '
+                'sync devtools/ci/index.html s3://{bucket}/')
+    cmd = template.format(
+            config=f.name,
+            bucket=BUCKET_NAME
+    )
+    return_val = subprocess.call(cmd.split())
+

--- a/devtools/ci/push-docs-to-s3.py
+++ b/devtools/ci/push-docs-to-s3.py
@@ -5,7 +5,7 @@ import subprocess
 import opentis.version
 
 
-BUCKET_NAME = 'openpathsampling'
+BUCKET_NAME = 'openpathsampling.org'
 if not opentis.version.release:
     PREFIX = 'latest'
 else:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: opentis
+  name: openpathsampling
   version: !!str dev
 
 requirements:


### PR DESCRIPTION
This PR does the following:
* Updated conda recipe name to `openpathsampling`
* Updated S3 bucket name to `openpathsampling.org`

Once merged, this should allow you to view the docs from http://openpathsampling.org and successfully grab conda packages from the `omnia` binstar.